### PR TITLE
Remove unused/duplicate dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 ### Changed
   - Remove unused dependencies, namely `babel-preset-react-hmre` and
     `babel-plugin-transform-export-extensions`.
+  - Remove `babel-plugin-syntax-flow` and `babel-plugin-transform-flow-strip-types`
+    as they are already part of the React preset.
 
 ## 2016-10-10
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change log
 
 ## [Unreleased]
+### Changed
+  - Remove unused dependencies, namely `babel-preset-react-hmre` and
+    `babel-plugin-transform-export-extensions`.
 
 ## 2016-10-10
 ### Changed

--- a/index.js
+++ b/index.js
@@ -11,8 +11,6 @@ module.exports = {
     "transform-decorators-legacy",
     "transform-class-properties",
     "transform-object-rest-spread",
-    "transform-flow-strip-types",
-    "syntax-flow",
     "syntax-trailing-function-commas",
   ]
 };

--- a/package.json
+++ b/package.json
@@ -25,14 +25,12 @@
     "babel-plugin-transform-async-to-generator": "^6.8.0",
     "babel-plugin-transform-class-properties": "^6.4.0",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
-    "babel-plugin-transform-export-extensions": "^6.4.0",
     "babel-plugin-transform-flow-strip-types": "^6.8.0",
     "babel-plugin-transform-object-assign": "^6.8.0",
     "babel-plugin-transform-object-rest-spread": "^6.3.13",
     "babel-plugin-transform-runtime": "^6.9.0",
     "babel-preset-es2015": "^6.3.13",
-    "babel-preset-react": "^6.3.13",
-    "babel-preset-react-hmre": "^1.1.0"
+    "babel-preset-react": "^6.3.13"
   },
   "peerDependencies": {
     "babel-runtime": "*"

--- a/package.json
+++ b/package.json
@@ -20,12 +20,10 @@
   "private": false,
   "dependencies": {
     "babel-plugin-react-transform": "^2.0.0",
-    "babel-plugin-syntax-flow": "^6.13.0",
     "babel-plugin-syntax-trailing-function-commas": "^6.5.0",
     "babel-plugin-transform-async-to-generator": "^6.8.0",
     "babel-plugin-transform-class-properties": "^6.4.0",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
-    "babel-plugin-transform-flow-strip-types": "^6.8.0",
     "babel-plugin-transform-object-assign": "^6.8.0",
     "babel-plugin-transform-object-rest-spread": "^6.3.13",
     "babel-plugin-transform-runtime": "^6.9.0",


### PR DESCRIPTION
Remove unused dependencies/plugins:
Namely  `babel-preset-react-hmre` and `babel-plugin-transform-export-extensions`.   
Those should not be imposed to every user, but rather set locally if needed. 

Remove duplicate dependencies/plugins:
Namely `babel-plugin-transform-flow-strip-types` and `babel-plugin-syntax-flow` as they are already included in the React preset. 
See https://github.com/babel/babel/blob/master/packages/babel-preset-react/src/index.js



