### PR TITLE
Add `flow-react-proptypes` plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change log
 
 ## [Unreleased]
+### Added
+  - The `flow-react-proptypes` plugin.
 
 ## 2016-10-10
 ### Changed

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ module.exports = {
       "polyfill": true,
       "regenerator": true
     }],
+    "flow-react-proptypes",
     "transform-async-to-generator",
     "transform-object-assign",
     "transform-decorators-legacy",

--- a/package.json
+++ b/package.json
@@ -14,11 +14,16 @@
     "url": "https://github.com/Gandi/babel-preset-gandi/issues"
   },
   "homepage": "https://github.com/Gandi/babel-preset-gandi",
-  "keywords": ["babel", "babel-preset", "gandi"],
+  "keywords": [
+    "babel",
+    "babel-preset",
+    "gandi"
+  ],
   "author": "Gandi",
   "license": "ISC",
   "private": false,
   "dependencies": {
+    "babel-plugin-flow-react-proptypes": "^0.17.2",
     "babel-plugin-react-transform": "^2.0.0",
     "babel-plugin-syntax-flow": "^6.13.0",
     "babel-plugin-syntax-trailing-function-commas": "^6.5.0",


### PR DESCRIPTION
Allows React propTypes warnings in console. Might ease propTypes documentation (external type files are not supported by react-docgen).

Plugin home:
https://github.com/brigand/babel-plugin-flow-react-proptypes

Discussion:
Should we scope it to a `BABEL_ENV`?  
Basically propTypes are stripped in production builds.  