### PR TITLE
Switch to babel-preset-env

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-Babel preset for Gandi JavaScript projects
-==========================================
+Babel preset for Gandi's JavaScript projects
+============================================
 
-Includes ES2015, React, as well as common transforms and polyfills.
+Includes ES2017+, React, Flow, as well as common transforms and polyfills.
 
 ## Installation
 
@@ -9,15 +9,27 @@ Includes ES2015, React, as well as common transforms and polyfills.
 $ npm install --save-dev @gandi/babel-preset-gandi
 ```
 
+
 ## Usage
 
 Add the following line to your `.babelrc` file:
 
 ``` json
 {
-  "presets": ["gandi"]
+  "presets": ["@gandi/gandi"]
 }
 ```
+
+Pass options to `babel-preset-env`
+
+``` json
+{
+  "presets": [["@gandi/gandi", { "modules": false }]]
+}
+```
+
+See the [full list of available options](https://github.com/babel/babel-preset-env#options).
+
 
 ## Changelog
 
@@ -32,9 +44,11 @@ Please open an [issue](https://github.com/Gandi/babel-preset-gandi/issues). If i
 
 Else you can start contributing.
 
+
 ### Code of conduct
 
 Be nice. Thanks.
+
 
 ### Contributors
 

--- a/index.js
+++ b/index.js
@@ -1,18 +1,46 @@
-module.exports = {
-  "presets": [ "es2015", "react" ],
-  "plugins": [
-     // "polyfill": true will polyfill built-ins such as Promise / Set / Symbol ...
-    ["transform-runtime", {
-      "polyfill": true,
-      "regenerator": true
-    }],
-    "transform-async-to-generator",
-    "transform-object-assign",
-    "transform-decorators-legacy",
-    "transform-class-properties",
-    "transform-object-rest-spread",
-    "transform-flow-strip-types",
-    "syntax-flow",
-    "syntax-trailing-function-commas",
-  ]
+/**
+ * [ES2017+]
+ * https://babeljs.io/docs/plugins/preset-env
+ *
+ * [Experimental]
+ * https://babeljs.io/docs/plugins/transform-object-rest-spread
+ * https://babeljs.io/docs/plugins/transform-class-properties
+ * https://github.com/loganfsmyth/babel-plugin-transform-decorators-legacy
+ * https://babeljs.io/docs/plugins/transform-decorators
+ *
+ * [Other]
+ * https://babeljs.io/docs/plugins/transform-runtime
+ */
+
+module.exports = (context, options) => {
+  const defaults = {
+    targets: {
+      browsers: ['last 2 versions', '> 1%'],
+      node: 8,
+    },
+  };
+
+  const presets = [
+    ['env', Object.assign(defaults, options)],
+    'react'
+  ];
+
+  const plugins = [
+    [
+      'transform-runtime',
+      {
+        helpers: true,
+        polyfill: true,
+        regenerator: true,
+      },
+    ],
+    'transform-class-properties',
+    'transform-decorators-legacy',
+    'transform-object-rest-spread',
+  ];
+
+  return {
+    presets,
+    plugins,
+  };
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gandi/babel-preset-gandi",
   "version": "1.0.0",
-  "description": "Babel preset used in GANDI's JavaScript projects. Includes ES2015, React, as well as common transforms and polyfills.",
+  "description": "Babel preset used in Gandi's JavaScript projects. Includes ES2017+, React, Flow as well as common transforms and polyfills.",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -14,25 +14,21 @@
     "url": "https://github.com/Gandi/babel-preset-gandi/issues"
   },
   "homepage": "https://github.com/Gandi/babel-preset-gandi",
-  "keywords": ["babel", "babel-preset", "gandi"],
+  "keywords": [
+    "babel",
+    "babel-preset",
+    "gandi"
+  ],
   "author": "Gandi",
   "license": "ISC",
   "private": false,
   "dependencies": {
-    "babel-plugin-react-transform": "^2.0.0",
-    "babel-plugin-syntax-flow": "^6.13.0",
-    "babel-plugin-syntax-trailing-function-commas": "^6.5.0",
-    "babel-plugin-transform-async-to-generator": "^6.8.0",
     "babel-plugin-transform-class-properties": "^6.4.0",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
-    "babel-plugin-transform-export-extensions": "^6.4.0",
-    "babel-plugin-transform-flow-strip-types": "^6.8.0",
-    "babel-plugin-transform-object-assign": "^6.8.0",
     "babel-plugin-transform-object-rest-spread": "^6.3.13",
     "babel-plugin-transform-runtime": "^6.9.0",
-    "babel-preset-es2015": "^6.3.13",
-    "babel-preset-react": "^6.3.13",
-    "babel-preset-react-hmre": "^1.1.0"
+    "babel-preset-env": "^1.6.0",
+    "babel-preset-react": "^6.3.13"
   },
   "peerDependencies": {
     "babel-runtime": "*"


### PR DESCRIPTION
- Switch to [babel-preset-env](https://github.com/babel/babel-preset-env).
- Remove unused dependencies and plugins.
- Allow for passing options, for instance whether to transpile ES2015 modules or not (used for the Webpack 3 migration).