### PR TITLE
Add syntax-dynamic-import babel plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change log
 
 ## [Unreleased]
+### Added
+  - Add `babel-plugin-syntax-dynamic-import`.
+    Enables using `import('foo/bar')` dynamic import syntax.
 
 ## 2.0.0 - 2017-11-07
 ### Changed

--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ module.exports = (context, options) => {
 
   const plugins = [
     [
+      'syntax-dynamic-import',
       'transform-runtime',
       {
         helpers: true,

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
+    "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "babel-plugin-transform-class-properties": "^6.4.0",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-plugin-transform-object-rest-spread": "^6.3.13",


### PR DESCRIPTION
Required for https://webpack.js.org/guides/code-splitting/#dynamic-imports