### PR TITLE
Add optional-chaining and nullish-coalescing plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change log
 
 ## [Unreleased]
+### Added
+  * Added optional chaining proposal transform plugin.
 
 ## 3.0.2 - 2019-01-22
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## [Unreleased]
 ### Added
-  * Added optional chaining proposal transform plugin.
+  * Added optional-chaining proposal transform plugin.
+  * Added nullish-coalescing-operator proposal transform plugin.
 
 ## 3.0.2 - 2019-01-22
 ### Changed

--- a/index.js
+++ b/index.js
@@ -6,7 +6,8 @@
  * https://babeljs.io/docs/en/babel-plugin-syntax-dynamic-import
  * https://babeljs.io/docs/en/babel-plugin-proposal-class-properties
  * https://babeljs.io/docs/en/babel-plugin-proposal-decorators
- * https://babeljs.io/docs/en/babel-plugin-proposal-optional-chaining.html
+ * https://babeljs.io/docs/en/babel-plugin-proposal-optional-chaining
+ * https://babeljs.io/docs/en/babel-plugin-proposal-nullish-coalescing-operator
  *
  * [React]
  * https://babeljs.io/docs/en/babel-preset-react
@@ -45,8 +46,9 @@ module.exports = (context, options) => {
 
   let plugins = [
     '@babel/plugin-syntax-dynamic-import',
-    '@babel/plugin-proposal-optional-chaining',
     '@babel/plugin-transform-flow-strip-types',
+    '@babel/plugin-proposal-optional-chaining',
+    '@babel/plugin-proposal-nullish-coalescing-operator',
     ['@babel/plugin-proposal-decorators', { legacy: true }],
     ['@babel/plugin-proposal-class-properties', { loose: true }],
     ['@babel/plugin-transform-runtime', runtimeOpts],

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@
  * https://babeljs.io/docs/en/babel-plugin-syntax-dynamic-import
  * https://babeljs.io/docs/en/babel-plugin-proposal-class-properties
  * https://babeljs.io/docs/en/babel-plugin-proposal-decorators
+ * https://babeljs.io/docs/en/babel-plugin-proposal-optional-chaining.html
  *
  * [React]
  * https://babeljs.io/docs/en/babel-preset-react
@@ -44,6 +45,7 @@ module.exports = (context, options) => {
 
   let plugins = [
     '@babel/plugin-syntax-dynamic-import',
+    '@babel/plugin-proposal-optional-chaining',
     '@babel/plugin-transform-flow-strip-types',
     ['@babel/plugin-proposal-decorators', { legacy: true }],
     ['@babel/plugin-proposal-class-properties', { loose: true }],

--- a/package-lock.json
+++ b/package-lock.json
@@ -322,6 +322,15 @@
         "@babel/plugin-syntax-optional-catch-binding": "^7.2.0"
       }
     },
+    "@babel/plugin-proposal-optional-chaining": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.2.0.tgz",
+      "integrity": "sha512-ea3Q6edZC/55wEBVZAEz42v528VulyO0eir+7uky/sT4XRcdkWJcFi1aPtitTlwUzGnECWJNExWww1SStt+yWw==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-optional-chaining": "^7.2.0"
+      }
+    },
     "@babel/plugin-proposal-unicode-property-regex": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.2.0.tgz",
@@ -392,6 +401,14 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.2.0.tgz",
       "integrity": "sha512-bDe4xKNhb0LI7IvZHiA13kff0KEfaGX/Hv4lMA9+7TEc63hMNvfKo6ZFpXhKuEp+II/q35Gc4NoMeDZyaUbj9w==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-optional-chaining": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.2.0.tgz",
+      "integrity": "sha512-HtGCtvp5Uq/jH/WNUPkK6b7rufnCPLLlDAFN7cmACoIjaOOiXxUt3SswU5loHqrhtqTsa/WoLQ1OQ1AGuZqaWA==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -304,6 +304,15 @@
         "@babel/plugin-syntax-json-strings": "^7.2.0"
       }
     },
+    "@babel/plugin-proposal-nullish-coalescing-operator": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.2.0.tgz",
+      "integrity": "sha512-QXj/YjFuFJd68oDvoc1e8aqLr2wz7Kofzvp6Ekd/o7MWZl+nZ0/cpStxND+hlZ7DpRWAp7OmuyT2areZ2V3YUA==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.2.0"
+      }
+    },
     "@babel/plugin-proposal-object-rest-spread": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.3.1.tgz",
@@ -385,6 +394,14 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.2.0.tgz",
       "integrity": "sha512-VyN4QANJkRW6lDBmENzRszvZf3/4AXaj9YR7GwrWeeN9tEBPuXbmDYVU9bYBN0D70zCWVwUy0HWq2553VCb6Hw==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.2.0.tgz",
+      "integrity": "sha512-lRCEaKE+LTxDQtgbYajI04ddt6WW0WJq57xqkAZ+s11h4YgfRHhVA/Y2VhfPzzFD4qeLHWg32DMp9HooY4Kqlg==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@babel/plugin-proposal-class-properties": "^7.3.0",
     "@babel/plugin-proposal-decorators": "^7.3.0",
+    "@babel/plugin-proposal-optional-chaining": "^7.2.0",
     "@babel/plugin-syntax-dynamic-import": "^7.2.0",
     "@babel/plugin-transform-runtime": "^7.2.0",
     "@babel/preset-env": "^7.3.1",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@babel/plugin-proposal-class-properties": "^7.3.0",
     "@babel/plugin-proposal-decorators": "^7.3.0",
+    "@babel/plugin-proposal-nullish-coalescing-operator": "^7.2.0",
     "@babel/plugin-proposal-optional-chaining": "^7.2.0",
     "@babel/plugin-syntax-dynamic-import": "^7.2.0",
     "@babel/plugin-transform-runtime": "^7.2.0",

--- a/test/__file_snapshots__/cjsm--nullish-coalescing-0
+++ b/test/__file_snapshots__/cjsm--nullish-coalescing-0
@@ -1,0 +1,6 @@
+"use strict";
+
+var _obj$foo;
+
+var obj = {};
+var foo = (_obj$foo = obj.foo) !== null && _obj$foo !== void 0 ? _obj$foo : 'default';

--- a/test/__file_snapshots__/cjsm--optional-chaining-0
+++ b/test/__file_snapshots__/cjsm--optional-chaining-0
@@ -1,0 +1,14 @@
+"use strict";
+
+var _obj$foo, _obj$foo$bar, _obj$qux;
+
+var obj = {
+  foo: {
+    bar: {
+      baz: 42
+    }
+  }
+};
+var baz = obj === null || obj === void 0 ? void 0 : (_obj$foo = obj.foo) === null || _obj$foo === void 0 ? void 0 : (_obj$foo$bar = _obj$foo.bar) === null || _obj$foo$bar === void 0 ? void 0 : _obj$foo$bar.baz; // 42
+
+var safe = obj === null || obj === void 0 ? void 0 : (_obj$qux = obj.qux) === null || _obj$qux === void 0 ? void 0 : _obj$qux.baz; // undefined

--- a/test/__file_snapshots__/esm--nullish-coalescing-0
+++ b/test/__file_snapshots__/esm--nullish-coalescing-0
@@ -1,0 +1,4 @@
+var _obj$foo;
+
+var obj = {};
+var foo = (_obj$foo = obj.foo) !== null && _obj$foo !== void 0 ? _obj$foo : 'default';

--- a/test/__file_snapshots__/esm--optional-chaining-0
+++ b/test/__file_snapshots__/esm--optional-chaining-0
@@ -1,0 +1,12 @@
+var _obj$foo, _obj$foo$bar, _obj$qux;
+
+var obj = {
+  foo: {
+    bar: {
+      baz: 42
+    }
+  }
+};
+var baz = obj === null || obj === void 0 ? void 0 : (_obj$foo = obj.foo) === null || _obj$foo === void 0 ? void 0 : (_obj$foo$bar = _obj$foo.bar) === null || _obj$foo$bar === void 0 ? void 0 : _obj$foo$bar.baz; // 42
+
+var safe = obj === null || obj === void 0 ? void 0 : (_obj$qux = obj.qux) === null || _obj$qux === void 0 ? void 0 : _obj$qux.baz; // undefined

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -45,6 +45,22 @@ let cases = [
     `,
   ],
   [
+    'optional chaining',
+    `
+    let obj = {
+      foo: {
+        bar: {
+          baz: 42,
+        },
+      },
+    };
+
+    let baz = obj?.foo?.bar?.baz; // 42
+
+    let safe = obj?.qux?.baz; // undefined
+    `,
+  ],
+  [
     'Runtime ponyfills',
     `
       new Map()

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -61,6 +61,14 @@ let cases = [
     `,
   ],
   [
+    'nullish coalescing',
+    `
+    let obj = {};
+
+    let foo = obj.foo ?? 'default';
+    `,
+  ],
+  [
     'Runtime ponyfills',
     `
       new Map()


### PR DESCRIPTION
### Proposals (stage 1)

https://github.com/tc39/proposal-optional-chaining  
https://github.com/tc39/proposal-nullish-coalescing  
https://github.com/tc39/proposals#stage-1  

### ESLint
Should be supported out of the box (babel-eslint)

### Flow
```
esproposal.optional_chaining=enable
esproposal.nullish_coalescing=enable
```

### TypeScript 

Who cares.

### Prettier

Supported.

### Conclusion

Ditch `lodash/get` or those pesky existential conditions.  
[No type loss](https://twitter.com/kangax/status/1088559859417710592).  
Prevent sketchy null values.  