### PR TITLE
WIP: Enable jsx useSpread option

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ module.exports = (context, options) => {
 
   let presets = [
     ['@babel/preset-env', envOpts],
-    '@babel/preset-react',
+    ['@babel/preset-react', { useSpread: true }],
     '@babel/preset-flow',
   ];
 

--- a/test/__file_snapshots__/cjsm--react-spread-0
+++ b/test/__file_snapshots__/cjsm--react-spread-0
@@ -2,8 +2,8 @@
 
 var _interopRequireDefault = require("@babel/runtime-corejs2/helpers/interopRequireDefault");
 
-var _extends2 = _interopRequireDefault(require("@babel/runtime-corejs2/helpers/extends"));
+var _objectSpread2 = _interopRequireDefault(require("@babel/runtime-corejs2/helpers/objectSpread2"));
 
-React.createElement("div", (0, _extends2.default)({
+React.createElement("div", (0, _objectSpread2.default)({
   a: true
 }, b), "hello");

--- a/test/__file_snapshots__/esm--react-spread-0
+++ b/test/__file_snapshots__/esm--react-spread-0
@@ -1,4 +1,4 @@
-import _extends from "@babel/runtime-corejs2/helpers/esm/extends";
-React.createElement("div", _extends({
+import _objectSpread from "@babel/runtime-corejs2/helpers/esm/objectSpread2";
+React.createElement("div", _objectSpread({
   a: true
 }, b), "hello");

--- a/test/__file_snapshots__/esmodules--react-spread-0
+++ b/test/__file_snapshots__/esmodules--react-spread-0
@@ -1,4 +1,4 @@
-import _extends from "@babel/runtime-corejs2/helpers/esm/extends";
-React.createElement("div", _extends({
+import _objectSpread from "@babel/runtime-corejs2/helpers/esm/objectSpread2";
+React.createElement("div", _objectSpread({
   a: true
 }, b), "hello");


### PR DESCRIPTION
Just trying the latest [jsx plugin `useSpread` option](https://babeljs.io/blog/2019/11/05/7.7.0#use-object-spread-in-compiled-jsx-10572-https-githubcom-babel-babel-pull-10572).

Unfortunately, even the `esmodules` target doesn't allow native spread yet.


https://caniuse.com/#feat=mdn-javascript_operators_spread_spread_in_object_literals
https://caniuse.com/#feat=es6-module

 