### PR TITLE
Use the modern JSX transform

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ module.exports = (context, options = {}) => {
 
   let presets = [
     ['@babel/preset-env', envOpts],
-    '@babel/preset-react',
+    ['@babel/preset-react', { runtime: 'automatic' }],
     '@babel/preset-flow',
   ];
 

--- a/test/__file_snapshots__/cjsm--React-class-component-0
+++ b/test/__file_snapshots__/cjsm--React-class-component-0
@@ -2,7 +2,7 @@
 
 var _interopRequireDefault = require("@babel/runtime-corejs2/helpers/interopRequireDefault").default;
 var _interopRequireWildcard = require("@babel/runtime-corejs2/helpers/interopRequireWildcard").default;
-var _extends2 = _interopRequireDefault(require("@babel/runtime-corejs2/helpers/extends"));
+var _objectSpread2 = _interopRequireDefault(require("@babel/runtime-corejs2/helpers/objectSpread2"));
 var _objectWithoutProperties2 = _interopRequireDefault(require("@babel/runtime-corejs2/helpers/objectWithoutProperties"));
 var _regeneratorRuntime2 = _interopRequireDefault(require("@babel/runtime-corejs2/helpers/regeneratorRuntime"));
 var _asyncToGenerator2 = _interopRequireDefault(require("@babel/runtime-corejs2/helpers/asyncToGenerator"));
@@ -11,6 +11,7 @@ var _createClass2 = _interopRequireDefault(require("@babel/runtime-corejs2/helpe
 var _callSuper2 = _interopRequireDefault(require("@babel/runtime-corejs2/helpers/callSuper"));
 var _inherits2 = _interopRequireDefault(require("@babel/runtime-corejs2/helpers/inherits"));
 var React = _interopRequireWildcard(require("react"));
+var _jsxRuntime = require("react/jsx-runtime");
 var _excluded = ["type"];
 var Button = /*#__PURE__*/function (_React$Component) {
   function Button() {
@@ -48,10 +49,12 @@ var Button = /*#__PURE__*/function (_React$Component) {
         _this$props$type = _this$props.type,
         type = _this$props$type === void 0 ? 'button' : _this$props$type,
         extraProps = (0, _objectWithoutProperties2.default)(_this$props, _excluded);
-      return /*#__PURE__*/React.createElement("button", (0, _extends2.default)({
+      return /*#__PURE__*/(0, _jsxRuntime.jsx)("button", (0, _objectSpread2.default)((0, _objectSpread2.default)({
         type: type,
         onClick: this.handleClick
-      }, extraProps), children);
+      }, extraProps), {}, {
+        children: children
+      }));
     }
   }]);
 }(React.Component);

--- a/test/__file_snapshots__/cjsm--React-function-component-0
+++ b/test/__file_snapshots__/cjsm--React-function-component-0
@@ -1,15 +1,18 @@
 "use strict";
 
 var _interopRequireDefault = require("@babel/runtime-corejs2/helpers/interopRequireDefault").default;
-var _extends2 = _interopRequireDefault(require("@babel/runtime-corejs2/helpers/extends"));
+var _objectSpread2 = _interopRequireDefault(require("@babel/runtime-corejs2/helpers/objectSpread2"));
 var _objectWithoutProperties2 = _interopRequireDefault(require("@babel/runtime-corejs2/helpers/objectWithoutProperties"));
+var _jsxRuntime = require("react/jsx-runtime");
 var _excluded = ["type", "children"];
 function Button(_ref) {
   var _ref$type = _ref.type,
     type = _ref$type === void 0 ? 'button' : _ref$type,
     children = _ref.children,
     extraProps = (0, _objectWithoutProperties2.default)(_ref, _excluded);
-  return /*#__PURE__*/React.createElement("button", (0, _extends2.default)({
+  return /*#__PURE__*/(0, _jsxRuntime.jsx)("button", (0, _objectSpread2.default)((0, _objectSpread2.default)({
     type: type
-  }, extraProps), children);
+  }, extraProps), {}, {
+    children: children
+  }));
 }

--- a/test/__file_snapshots__/cjsm--jsx-0
+++ b/test/__file_snapshots__/cjsm--jsx-0
@@ -1,5 +1,8 @@
 "use strict";
 
+var _jsxRuntime = require("react/jsx-runtime");
 var A = function A() {
-  return /*#__PURE__*/React.createElement("div", null, "hello");
+  return /*#__PURE__*/(0, _jsxRuntime.jsx)("div", {
+    children: "hello"
+  });
 };

--- a/test/__file_snapshots__/cjsm--jsx-spread-0
+++ b/test/__file_snapshots__/cjsm--jsx-spread-0
@@ -1,7 +1,10 @@
 "use strict";
 
 var _interopRequireDefault = require("@babel/runtime-corejs2/helpers/interopRequireDefault").default;
-var _extends2 = _interopRequireDefault(require("@babel/runtime-corejs2/helpers/extends"));
-/*#__PURE__*/React.createElement("div", (0, _extends2.default)({
+var _objectSpread2 = _interopRequireDefault(require("@babel/runtime-corejs2/helpers/objectSpread2"));
+var _jsxRuntime = require("react/jsx-runtime");
+/*#__PURE__*/(0, _jsxRuntime.jsx)("div", (0, _objectSpread2.default)((0, _objectSpread2.default)({
   a: true
-}, b), "hello");
+}, b), {}, {
+  children: "hello"
+}));

--- a/test/__file_snapshots__/esm--React-class-component-0
+++ b/test/__file_snapshots__/esm--React-class-component-0
@@ -1,4 +1,4 @@
-import _extends from "@babel/runtime-corejs2/helpers/extends";
+import _objectSpread from "@babel/runtime-corejs2/helpers/objectSpread2";
 import _objectWithoutProperties from "@babel/runtime-corejs2/helpers/objectWithoutProperties";
 import _regeneratorRuntime from "@babel/runtime-corejs2/helpers/regeneratorRuntime";
 import _asyncToGenerator from "@babel/runtime-corejs2/helpers/asyncToGenerator";
@@ -8,6 +8,7 @@ import _callSuper from "@babel/runtime-corejs2/helpers/callSuper";
 import _inherits from "@babel/runtime-corejs2/helpers/inherits";
 var _excluded = ["type"];
 import * as React from 'react';
+import { jsx as _jsx } from "react/jsx-runtime";
 var Button = /*#__PURE__*/function (_React$Component) {
   function Button() {
     var _this;
@@ -44,10 +45,12 @@ var Button = /*#__PURE__*/function (_React$Component) {
         _this$props$type = _this$props.type,
         type = _this$props$type === void 0 ? 'button' : _this$props$type,
         extraProps = _objectWithoutProperties(_this$props, _excluded);
-      return /*#__PURE__*/React.createElement("button", _extends({
+      return /*#__PURE__*/_jsx("button", _objectSpread(_objectSpread({
         type: type,
         onClick: this.handleClick
-      }, extraProps), children);
+      }, extraProps), {}, {
+        children: children
+      }));
     }
   }]);
 }(React.Component);

--- a/test/__file_snapshots__/esm--React-function-component-0
+++ b/test/__file_snapshots__/esm--React-function-component-0
@@ -1,12 +1,15 @@
-import _extends from "@babel/runtime-corejs2/helpers/extends";
+import _objectSpread from "@babel/runtime-corejs2/helpers/objectSpread2";
 import _objectWithoutProperties from "@babel/runtime-corejs2/helpers/objectWithoutProperties";
 var _excluded = ["type", "children"];
+import { jsx as _jsx } from "react/jsx-runtime";
 function Button(_ref) {
   var _ref$type = _ref.type,
     type = _ref$type === void 0 ? 'button' : _ref$type,
     children = _ref.children,
     extraProps = _objectWithoutProperties(_ref, _excluded);
-  return /*#__PURE__*/React.createElement("button", _extends({
+  return /*#__PURE__*/_jsx("button", _objectSpread(_objectSpread({
     type: type
-  }, extraProps), children);
+  }, extraProps), {}, {
+    children: children
+  }));
 }

--- a/test/__file_snapshots__/esm--jsx-0
+++ b/test/__file_snapshots__/esm--jsx-0
@@ -1,3 +1,6 @@
+import { jsx as _jsx } from "react/jsx-runtime";
 var A = function A() {
-  return /*#__PURE__*/React.createElement("div", null, "hello");
+  return /*#__PURE__*/_jsx("div", {
+    children: "hello"
+  });
 };

--- a/test/__file_snapshots__/esm--jsx-spread-0
+++ b/test/__file_snapshots__/esm--jsx-spread-0
@@ -1,4 +1,7 @@
-import _extends from "@babel/runtime-corejs2/helpers/extends";
-/*#__PURE__*/React.createElement("div", _extends({
+import _objectSpread from "@babel/runtime-corejs2/helpers/objectSpread2";
+import { jsx as _jsx } from "react/jsx-runtime";
+/*#__PURE__*/_jsx("div", _objectSpread(_objectSpread({
   a: true
-}, b), "hello");
+}, b), {}, {
+  children: "hello"
+}));

--- a/test/__file_snapshots__/esmodules--React-class-component-0
+++ b/test/__file_snapshots__/esmodules--React-class-component-0
@@ -1,7 +1,8 @@
-import _extends from "@babel/runtime-corejs2/helpers/extends";
+import _objectSpread from "@babel/runtime-corejs2/helpers/objectSpread2";
 import _objectWithoutProperties from "@babel/runtime-corejs2/helpers/objectWithoutProperties";
 const _excluded = ["type"];
 import * as React from 'react';
+import { jsx as _jsx } from "react/jsx-runtime";
 class Button extends React.Component {
   constructor(...args) {
     super(...args);
@@ -16,9 +17,11 @@ class Button extends React.Component {
         type = 'button'
       } = _this$props,
       extraProps = _objectWithoutProperties(_this$props, _excluded);
-    return /*#__PURE__*/React.createElement("button", _extends({
+    return /*#__PURE__*/_jsx("button", _objectSpread(_objectSpread({
       type: type,
       onClick: this.handleClick
-    }, extraProps), children);
+    }, extraProps), {}, {
+      children: children
+    }));
   }
 }

--- a/test/__file_snapshots__/esmodules--React-function-component-0
+++ b/test/__file_snapshots__/esmodules--React-function-component-0
@@ -1,13 +1,16 @@
-import _extends from "@babel/runtime-corejs2/helpers/extends";
+import _objectSpread from "@babel/runtime-corejs2/helpers/objectSpread2";
 import _objectWithoutProperties from "@babel/runtime-corejs2/helpers/objectWithoutProperties";
 const _excluded = ["type", "children"];
+import { jsx as _jsx } from "react/jsx-runtime";
 function Button(_ref) {
   let {
       type = 'button',
       children
     } = _ref,
     extraProps = _objectWithoutProperties(_ref, _excluded);
-  return /*#__PURE__*/React.createElement("button", _extends({
+  return /*#__PURE__*/_jsx("button", _objectSpread(_objectSpread({
     type: type
-  }, extraProps), children);
+  }, extraProps), {}, {
+    children: children
+  }));
 }

--- a/test/__file_snapshots__/esmodules--jsx-0
+++ b/test/__file_snapshots__/esmodules--jsx-0
@@ -1,1 +1,4 @@
-let A = () => /*#__PURE__*/React.createElement("div", null, "hello");
+import { jsx as _jsx } from "react/jsx-runtime";
+let A = () => /*#__PURE__*/_jsx("div", {
+  children: "hello"
+});

--- a/test/__file_snapshots__/esmodules--jsx-spread-0
+++ b/test/__file_snapshots__/esmodules--jsx-spread-0
@@ -1,4 +1,7 @@
-import _extends from "@babel/runtime-corejs2/helpers/extends";
-/*#__PURE__*/React.createElement("div", _extends({
+import _objectSpread from "@babel/runtime-corejs2/helpers/objectSpread2";
+import { jsx as _jsx } from "react/jsx-runtime";
+/*#__PURE__*/_jsx("div", _objectSpread(_objectSpread({
   a: true
-}, b), "hello");
+}, b), {}, {
+  children: "hello"
+}));

--- a/test/__file_snapshots__/node--React-class-component-0
+++ b/test/__file_snapshots__/node--React-class-component-0
@@ -1,9 +1,8 @@
 "use strict";
 
 var _interopRequireWildcard = require("@babel/runtime-corejs2/helpers/interopRequireWildcard").default;
-var _interopRequireDefault = require("@babel/runtime-corejs2/helpers/interopRequireDefault").default;
-var _extends2 = _interopRequireDefault(require("@babel/runtime-corejs2/helpers/extends"));
 var React = _interopRequireWildcard(require("react"));
+var _jsxRuntime = require("react/jsx-runtime");
 class Button extends React.Component {
   constructor(...args) {
     super(...args);
@@ -17,9 +16,11 @@ class Button extends React.Component {
       type = 'button',
       ...extraProps
     } = this.props;
-    return /*#__PURE__*/React.createElement("button", (0, _extends2.default)({
+    return /*#__PURE__*/(0, _jsxRuntime.jsx)("button", {
       type: type,
-      onClick: this.handleClick
-    }, extraProps), children);
+      onClick: this.handleClick,
+      ...extraProps,
+      children: children
+    });
   }
 }

--- a/test/__file_snapshots__/node--React-function-component-0
+++ b/test/__file_snapshots__/node--React-function-component-0
@@ -1,13 +1,14 @@
 "use strict";
 
-var _interopRequireDefault = require("@babel/runtime-corejs2/helpers/interopRequireDefault").default;
-var _extends2 = _interopRequireDefault(require("@babel/runtime-corejs2/helpers/extends"));
+var _jsxRuntime = require("react/jsx-runtime");
 function Button({
   type = 'button',
   children,
   ...extraProps
 }) {
-  return /*#__PURE__*/React.createElement("button", (0, _extends2.default)({
-    type: type
-  }, extraProps), children);
+  return /*#__PURE__*/(0, _jsxRuntime.jsx)("button", {
+    type: type,
+    ...extraProps,
+    children: children
+  });
 }

--- a/test/__file_snapshots__/node--jsx-0
+++ b/test/__file_snapshots__/node--jsx-0
@@ -1,3 +1,6 @@
 "use strict";
 
-let A = () => /*#__PURE__*/React.createElement("div", null, "hello");
+var _jsxRuntime = require("react/jsx-runtime");
+let A = () => /*#__PURE__*/(0, _jsxRuntime.jsx)("div", {
+  children: "hello"
+});

--- a/test/__file_snapshots__/node--jsx-spread-0
+++ b/test/__file_snapshots__/node--jsx-spread-0
@@ -1,7 +1,8 @@
 "use strict";
 
-var _interopRequireDefault = require("@babel/runtime-corejs2/helpers/interopRequireDefault").default;
-var _extends2 = _interopRequireDefault(require("@babel/runtime-corejs2/helpers/extends"));
-/*#__PURE__*/React.createElement("div", (0, _extends2.default)({
-  a: true
-}, b), "hello");
+var _jsxRuntime = require("react/jsx-runtime");
+/*#__PURE__*/(0, _jsxRuntime.jsx)("div", {
+  a: true,
+  ...b,
+  children: "hello"
+});


### PR DESCRIPTION
https://react.dev/blog/2024/04/25/react-19-upgrade-guide#new-jsx-transform-is-now-required

New JSX Transform is now required in React 19:

> Your app (or one of its dependencies) is using an outdated JSX transform.
> Update to the modern JSX transform for faster performance:
> https://react.dev/link/new-jsx-transform"

---

Published `@gandi/babel-preset-gandi@jsx` to test this: it seems to work without issues both with react@18 and react@rc (19). Do we merge just this bit or wait for #51?