### PR TITLE
Proposals and plugin api

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ module.exports = (context, options = {}) => {
 
   let envOpts = {
     bugfixes: true,
+    shippedProposals: true,
     ...envOptions,
   };
 

--- a/index.js
+++ b/index.js
@@ -11,13 +11,19 @@
  * [Hermes Parser]
  * https://github.com/facebook/hermes/blob/main/tools/hermes-parser/js/babel-plugin-syntax-hermes-parser
  *
- * [Other]
+ * [Ponyfills]
  * https://babeljs.io/docs/en/babel-plugin-transform-runtime
  */
 
+const { declarePreset } = require('@babel/helper-plugin-utils');
+const presetEnv = require('@babel/preset-env');
+const presetFlow = require('@babel/preset-flow');
+const presetReact = require('@babel/preset-react');
+const transformRuntime = require('@babel/plugin-transform-runtime');
+const syntaxHermesParser = require('babel-plugin-syntax-hermes-parser');
+
 /**
- * Notes
- *
+ * [Notes]
  * Presets are run in the reverse order they are defined.
  * Plugins are run in the order they are defined below,
  * but they are run *before* presets.
@@ -28,7 +34,9 @@
  *    See https://github.com/babel/babel/issues/9297#issuecomment-453750049
  */
 
-module.exports = (context, options = {}) => {
+module.exports = declarePreset((api, options = {}) => {
+  api.assertVersion(7);
+
   let { parser = 'babel', ...envOptions } = options;
 
   let envOpts = {
@@ -49,19 +57,15 @@ module.exports = (context, options = {}) => {
     version: '7.25.0', // 1
   };
 
-  let presets = [
-    ['@babel/preset-env', envOpts],
-    ['@babel/preset-react', reactOpts],
-    '@babel/preset-flow',
-  ];
+  let presets = [[presetEnv, envOpts], [presetReact, reactOpts], presetFlow];
 
   let plugins = [
-    ...(parser === 'hermes' ? ['babel-plugin-syntax-hermes-parser'] : []),
-    ['@babel/plugin-transform-runtime', runtimeOpts],
+    ...(parser === 'hermes' ? [syntaxHermesParser] : []),
+    [transformRuntime, runtimeOpts],
   ];
 
   return {
     presets,
     plugins,
   };
-};
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,9 +6,10 @@
   "packages": {
     "": {
       "name": "@gandi/babel-preset-gandi",
-      "version": "6.1.0",
+      "version": "6.2.0",
       "license": "ISC",
       "dependencies": {
+        "@babel/helper-plugin-utils": "^7.24.8",
         "@babel/plugin-transform-runtime": "^7.24.7",
         "@babel/preset-env": "^7.25.3",
         "@babel/preset-flow": "^7.24.7",
@@ -292,6 +293,7 @@
       "version": "7.24.8",
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.8.tgz",
       "integrity": "sha512-FFWx5142D8h2Mgr/iPVGH5G7w6jDn4jUSpZTyDnQO0Yn7Ks2Kuz6Pci8H6MPCoUJegd/UZQ3tAvfLCxQSnWWwg==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "browserslist": "$browserslist"
   },
   "dependencies": {
+    "@babel/helper-plugin-utils": "^7.24.8",
     "@babel/plugin-transform-runtime": "^7.24.7",
     "@babel/preset-env": "^7.25.3",
     "@babel/preset-flow": "^7.24.7",

--- a/test/__file_snapshots__/babel-cjsm---Proposals--import-attributes-0
+++ b/test/__file_snapshots__/babel-cjsm---Proposals--import-attributes-0
@@ -1,0 +1,4 @@
+"use strict";
+
+var _interopRequireDefault = require("@babel/runtime-corejs3/helpers/interopRequireDefault").default;
+var _styles = _interopRequireDefault(require("styles.css"));

--- a/test/__file_snapshots__/babel-esm---Proposals--import-attributes-0
+++ b/test/__file_snapshots__/babel-esm---Proposals--import-attributes-0
@@ -1,0 +1,1 @@
+import styles from 'styles.css' with { type: 'css' };

--- a/test/__file_snapshots__/babel-node---Proposals--import-attributes-0
+++ b/test/__file_snapshots__/babel-node---Proposals--import-attributes-0
@@ -1,0 +1,4 @@
+"use strict";
+
+var _interopRequireDefault = require("@babel/runtime-corejs3/helpers/interopRequireDefault").default;
+var _styles = _interopRequireDefault(require("styles.css"));

--- a/test/babel.spec.js
+++ b/test/babel.spec.js
@@ -6,9 +6,10 @@ const preset = require('../');
 const es = require('./fixtures/es');
 const flow = require('./fixtures/flow');
 const react = require('./fixtures/react');
+const proposals = require('./fixtures/proposals');
 const regressions = require('./fixtures/regressions');
 
-let cases = [...es, ...flow, ...react, ...regressions];
+let cases = [...es, ...flow, ...react, ...proposals, ...regressions];
 
 expect.extend({ toMatchFile });
 

--- a/test/fixtures/proposals.js
+++ b/test/fixtures/proposals.js
@@ -1,0 +1,8 @@
+module.exports = [
+  [
+    'Proposals: import attributes',
+    `
+    import styles from 'styles.css' with { type: 'css' };
+    `,
+  ],
+];


### PR DESCRIPTION
- Adding `shippedProposals`  allow for using new ES features without a syntax error, but will not be transpiled or ponyfilled.
- Follow the Babel presets "best practices" in how we declare the preset.
